### PR TITLE
upgrade-requirements

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -10,7 +10,7 @@ aiofiles 23.2.1
     Asyncio support for files
     Copyright 2016 Tin Tvrtkovic
 
-aiohttp 3.9.3
+aiohttp 3.9.5
 
     LICENSE:
        Copyright aio-libs contributors.
@@ -47,9 +47,9 @@ aiohttp 3.9.3
     Alexander Travov
     Alexandru Mihai
     Alexey Firsov
+    Alexey Nikitin
     Alexey Popravka
     Alexey Stepanov
-    Almaz Salakhov
     Amin Etesamian
     Amit Tulshyan
     Amy Boyle
@@ -66,7 +66,6 @@ aiohttp 3.9.3
     Antoine Pietri
     Anton Kasyanov
     Anton Zhdan-Pushkin
-    Arie Bovenberg
     Arseny Timoniq
     Artem Yushkovskiy
     Arthur Darcet
@@ -78,7 +77,6 @@ aiohttp 3.9.3
     Benedikt Reinartz
     Bob Haddleton
     Boris Feld
-    Borys Vorona
     Boyi Chen
     Brett Cannon
     Brian Bouterse
@@ -106,7 +104,6 @@ aiohttp 3.9.3
     Daniel Golding
     Daniel Grossmann-Kavanagh
     Daniel Nelson
-    Daniele Trifirò
     Danny Song
     David Bibb
     David Michael Brown
@@ -130,13 +127,11 @@ aiohttp 3.9.3
     Eduard Iskandarov
     Eli Ribble
     Elizabeth Leddy
-    Emil Melnikov
     Enrique Saez
     Eric Sheng
     Erich Healy
     Erik Peterson
     Eugene Chernyshov
-    Eugene Ershov
     Eugene Naydenov
     Eugene Nikolaiev
     Eugene Tolmachev
@@ -277,7 +272,6 @@ aiohttp 3.9.3
     Nándor Mátravölgyi
     Oisin Aylward
     Olaf Conradi
-    Oleg Höfling
     Pahaz Blinov
     Panagiotis Kolokotronis
     Pankaj Pandey
@@ -303,7 +297,6 @@ aiohttp 3.9.3
     Required Field
     Robert Lu
     Robert Nikolich
-    Roman Markeloff
     Roman Podoliaka
     Rong Zhang
     Samir Akarioh
@@ -354,7 +347,6 @@ aiohttp 3.9.3
     Viacheslav Greshilov
     Victor Collod
     Victor Kovtun
-    Victor Makarov
     Vikas Kawadia
     Viktor Danyliuk
     Ville Skyttä
@@ -379,7 +371,6 @@ aiohttp 3.9.3
     William S.
     Wilson Ong
     wouter bolsterlee
-    Xiang Li
     Yang Zhou
     Yannick Koechlin
     Yannick Péroux
@@ -396,7 +387,6 @@ aiohttp 3.9.3
     Zainab Lawal
     Zeal Wierslee
     Zlatan Sičanica
-    Łukasz Setla
     Марк Коренберг
     Семён Марьясин
 
@@ -477,12 +467,12 @@ frozenlist 1.4.1
     Paul Colomiets
 
 
-idna 3.6
+idna 3.7
 
     LICENSE:
     BSD 3-Clause License
 
-    Copyright (c) 2013-2023, Kim Davies and contributors.
+    Copyright (c) 2013-2024, Kim Davies and contributors.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 appdirs==1.4.4
 distlib==0.3.8
-filelock==3.13.3
+filelock==3.13.4
 iniconfig==2.0.0
 jedi==0.19.1
 mypy==1.9.0
 mypy-extensions==1.0.0
 packaging==24.0
-parso==0.8.3
+parso==0.8.4
 platformdirs==4.2.0
 pluggy==1.4.0
 prompt-toolkit==3.0.43
@@ -14,7 +14,7 @@ ptpython==3.0.26
 pygments==2.17.2
 pytest==8.1.1
 requirements-tools==2.1.0
-types-aiofiles==23.2.0.20240311
-typing-extensions==4.10.0
-virtualenv==20.25.1
+types-aiofiles==23.2.0.20240403
+typing-extensions==4.11.0
+virtualenv==20.25.3
 wcwidth==0.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiofiles==23.2.1
-aiohttp==3.9.3
+aiohttp==3.9.5
 aiosignal==1.3.1
 aiosqlite==0.20.0
 attrs==23.2.0
 frozenlist==1.4.1
-idna==3.6
+idna==3.7
 multidict==6.0.5
 yarl==1.9.4


### PR DESCRIPTION
This closes #12 and #13 from dependabot, the correct way, by upgrading all packages. The churn in the aiohttp contributors is because I accidentally grabbed the contributor list from the main branch previously, now I grabbed it from 3.9.5 tag correctly.