### PR TITLE
Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
           venv/bin/python -m kconfigs.main config.ini \
               --state ../gh-pages/state.json \
               --output-dir ../gh-pages/out
+          venv/bin/python -m kconfigs.cleanup config.ini \
+              --input-dir ../gh-pages/out
           venv/bin/python -m kconfigs.analyzer config.ini \
               --input-dir ../gh-pages/out \
               --output-file ../gh-pages/docs/summary.json

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ venv:
 .PHONY: run
 run:
 	venv/bin/python -m kconfigs.main config.ini
+	venv/bin/python -m kconfigs.cleanup config.ini
 	venv/bin/python -m kconfigs.analyzer config.ini
 
 .PHONY: dev

--- a/config.ini
+++ b/config.ini
@@ -366,17 +366,6 @@ index = http://archive.ubuntu.com/ubuntu/
 codename = jammy
 key = ubuntu
 
-[ubuntu_lunar_x86_64]
-name = Ubuntu
-version = 23.04 Lunar
-arch = x86_64
-package = linux-generic
-fetcher = kconfigs.deb.DebFetcher
-extractor = kconfigs.deb.DebExtractor
-index = http://archive.ubuntu.com/ubuntu/
-codename = lunar
-key = ubuntu
-
 [ubuntu_mantic_x86_64]
 name = Ubuntu
 version = 23.10 Mantic
@@ -386,6 +375,17 @@ fetcher = kconfigs.deb.DebFetcher
 extractor = kconfigs.deb.DebExtractor
 index = http://archive.ubuntu.com/ubuntu/
 codename = mantic
+key = ubuntu
+
+[ubuntu_noble_x86_64]
+name = Ubuntu
+version = 24.04 LTS Noble
+arch = x86_64
+package = linux-generic
+fetcher = kconfigs.deb.DebFetcher
+extractor = kconfigs.deb.DebExtractor
+index = http://archive.ubuntu.com/ubuntu/
+codename = noble
 key = ubuntu
 
 ## Ubuntu aarch64
@@ -412,17 +412,6 @@ index = http://ports.ubuntu.com/
 codename = jammy
 key = ubuntu
 
-[ubuntu_lunar_aarch64]
-name = Ubuntu
-version = 23.04 Lunar
-arch = aarch64
-package = linux-generic
-fetcher = kconfigs.deb.DebFetcher
-extractor = kconfigs.deb.DebExtractor
-index = http://ports.ubuntu.com/
-codename = lunar
-key = ubuntu
-
 [ubuntu_mantic_aarch64]
 name = Ubuntu
 version = 23.10 Mantic
@@ -432,6 +421,17 @@ fetcher = kconfigs.deb.DebFetcher
 extractor = kconfigs.deb.DebExtractor
 index = http://ports.ubuntu.com/
 codename = mantic
+key = ubuntu
+
+[ubuntu_noble_aarch64]
+name = Ubuntu
+version = 24.04 LTS Noble
+arch = aarch64
+package = linux-generic
+fetcher = kconfigs.deb.DebFetcher
+extractor = kconfigs.deb.DebExtractor
+index = http://ports.ubuntu.com/
+codename = noble
 key = ubuntu
 
 ## Debian x86_64

--- a/kconfigs/cleanup.py
+++ b/kconfigs/cleanup.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the terms of the GNU General Public License.
+import argparse
+import shutil
+from configparser import ConfigParser
+from pathlib import Path
+
+from kconfigs.fetcher import DistroConfig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Distribution kconfig combiner and analyzer"
+    )
+    parser.add_argument(
+        "config",
+        help="configuration file",
+        type=Path,
+    )
+    parser.add_argument(
+        "--input-dir",
+        help="directory containing configs (--output-dir from downloader)",
+        type=Path,
+        default=Path.cwd() / "out",
+    )
+
+    args = parser.parse_args()
+
+    cfg = ConfigParser()
+    cfg.read(args.config)
+    distros = [
+        DistroConfig(**dict(cfg[sec])) for sec in cfg.sections()  # type: ignore
+    ]
+    names = set(d.unique_name for d in distros)
+    for path in args.input_dir.iterdir():
+        if path.name not in names:
+            shutil.rmtree(path)
+            print(f'Removing "{path.name}"')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Update configs for 24.04 (removing 23.04 which is out of support). Add the ability for the Github actions to cleanup configs which are not conifgured, so 23.04 will actually get removed.