### PR TITLE
upstream: drop 6.7

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -544,16 +544,6 @@ extractor = kconfigs.upstream.DefconfigExtractor
 index = https://www.kernel.org/feeds/kdist.xml
 key = gregkh
 
-[upstream_6.7_x86_64]
-name = Upstream Default
-version = 6.7
-arch = x86_64
-package = linux
-fetcher = kconfigs.upstream.UpstreamFetcher
-extractor = kconfigs.upstream.DefconfigExtractor
-index = https://www.kernel.org/feeds/kdist.xml
-key = gregkh
-
 [upstream_6.6_x86_64]
 name = Upstream Default
 version = 6.6
@@ -618,16 +608,6 @@ key = gregkh
 [upstream_6.8_aarch64]
 name = Upstream Default
 version = 6.8
-arch = aarch64
-package = linux
-fetcher = kconfigs.upstream.UpstreamFetcher
-extractor = kconfigs.upstream.DefconfigExtractor
-index = https://www.kernel.org/feeds/kdist.xml
-key = gregkh
-
-[upstream_6.7_aarch64]
-name = Upstream Default
-version = 6.7
 arch = aarch64
 package = linux
 fetcher = kconfigs.upstream.UpstreamFetcher


### PR DESCRIPTION
It has been removed from the kernel.org site, presumably it is out of support.