### PR TITLE
Remove CentOS 8 Stream

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -300,16 +300,6 @@ extractor = kconfigs.rpm.RpmExtractor
 index = http://mirror.centos.org/centos/7/updates/x86_64/
 key = RPM-GPG-KEY-CentOS-7
 
-[centos8_x86_64]
-name = CentOS
-version = 8 Stream
-arch = x86_64
-package = kernel-core
-fetcher = kconfigs.rpm.RpmFetcher
-extractor = kconfigs.rpm.RpmExtractor
-index = http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-key = RPM-GPG-KEY-CentOS-Official
-
 [centos9_x86_64]
 name = CentOS
 version = 9 Stream
@@ -331,16 +321,6 @@ index = https://mirror.stream.centos.org/SIGs/9-stream/hyperscale/x86_64/package
 key = RPM-GPG-KEY-CentOS-SIG-HyperScale
 
 ## CentOS aarch64
-
-[centos8_aarch64]
-name = CentOS
-version = 8 Stream
-arch = aarch64
-package = kernel-core
-fetcher = kconfigs.rpm.RpmFetcher
-extractor = kconfigs.rpm.RpmExtractor
-index = http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/
-key = RPM-GPG-KEY-CentOS-Official
 
 [centos9_aarch64]
 name = CentOS


### PR DESCRIPTION
It is now EOL and the Yum repositories have been removed. For review of CentOS 8 / RHEL 8 kernel configurations, users can see the earlier kconfigs versions (prior to the EOL date), or refer to Oracle Linux 8 Red Hat Compatible Kernel (RHCK).