### PR TITLE
Remove 6.8 and CentOS 7

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -544,16 +544,6 @@ extractor = kconfigs.upstream.DefconfigExtractor
 index = https://www.kernel.org/feeds/kdist.xml
 key = gregkh
 
-[upstream_6.8_x86_64]
-name = Upstream Default
-version = 6.8
-arch = x86_64
-package = linux
-fetcher = kconfigs.upstream.UpstreamFetcher
-extractor = kconfigs.upstream.DefconfigExtractor
-index = https://www.kernel.org/feeds/kdist.xml
-key = gregkh
-
 [upstream_6.6_x86_64]
 name = Upstream Default
 version = 6.6
@@ -617,16 +607,6 @@ key = NOVERIFY-GITHUB
 [upstream_6.9_aarch64]
 name = Upstream Default
 version = 6.9
-arch = aarch64
-package = linux
-fetcher = kconfigs.upstream.UpstreamFetcher
-extractor = kconfigs.upstream.DefconfigExtractor
-index = https://www.kernel.org/feeds/kdist.xml
-key = gregkh
-
-[upstream_6.8_aarch64]
-name = Upstream Default
-version = 6.8
 arch = aarch64
 package = linux
 fetcher = kconfigs.upstream.UpstreamFetcher

--- a/config.ini
+++ b/config.ini
@@ -290,16 +290,6 @@ key = asahi.gpg
 
 ## CentOS x86_64
 
-[centos7_x86_64]
-name = CentOS
-version = 7
-arch = x86_64
-package = kernel
-fetcher = kconfigs.rpm.RpmFetcher
-extractor = kconfigs.rpm.RpmExtractor
-index = http://mirror.centos.org/centos/7/updates/x86_64/
-key = RPM-GPG-KEY-CentOS-7
-
 [centos9_x86_64]
 name = CentOS
 version = 9 Stream


### PR DESCRIPTION
Upstream 6.8 is gone from kernel.org. CentOS 7 dropped support on schedule and the archives give 404.