### PR TITLE
Fix mypy pre-commit hook parallelism

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,9 @@ repos:
         name: mypy
         entry: .venv/bin/mypy
         language: system
-        args: [--strict, --disallow-untyped-calls]
+        args: [--strict, --disallow-untyped-calls, kconfigs, tests]
         files: "^.*.py$"
+        pass_filenames: false
         verbose: true
 -   repo: https://github.com/netromdk/vermin
     rev: v1.8.0


### PR DESCRIPTION
Run mypy once against the whole project instead of letting pre-commit pass batches of filenames. This avoids concurrent mypy invocations sharing cache state and triggering internal errors in CI.